### PR TITLE
Chapter 25

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@4db96194c378173c656ce18a155ffc14a9fc4355
       - name: Run tests
-#       env:  # Add environment variables required for tests
+        env:
+          MOZ_HEADLESS: 1
         run: |
           just test
 

--- a/src/functional_tests/base.py
+++ b/src/functional_tests/base.py
@@ -4,7 +4,6 @@ import time
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
-from selenium.webdriver import FirefoxOptions
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
@@ -15,10 +14,6 @@ MAX_WAIT = 10
 
 
 def start_browser():
-    if not os.environ.get("GRAPHICAL_FUNCTIONAL_TESTS"):
-        options = FirefoxOptions()
-        options.add_argument("--headless")
-        return webdriver.Firefox(options=options)
     return webdriver.Firefox()
 
 


### PR DESCRIPTION
- Use `MOZ_HEADLESS` to toggle headless mode instead

Note: Since we do not use GitLab at Bennett, this chapter was skipped.
I might return to the screenshotting stuff, but it's not very likely since there's a much higher chance of me using playwright over selenium.