### PR TITLE
Fix messy `uv` integration in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # I was using 3.12 throughout the tutorial so use 3.12 instead
 FROM python:3.12-slim
 
-# hadolint ignore=DL3013
-RUN python -m pip install uv --no-cache-dir
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
@@ -13,9 +12,10 @@ ENV UV_LINK_MODE=copy \
 RUN uv venv --python-preference system
 ENV PATH="/venv/bin:$PATH"
 
-COPY pyproject.toml /pyproject.toml
-COPY uv.lock /uv.lock
-RUN uv sync  --frozen --no-dev --no-install-project
+RUN --mount=type=cache,target=/root/.cache \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync  --frozen --no-dev --no-install-project
 
 COPY src /src
 

--- a/justfile
+++ b/justfile
@@ -46,7 +46,7 @@ _uv *args: virtualenv
         export UV_EXCLUDE_NEWER=$TIMESTAMP
     fi
 
-    uv {{ args }}
+    uv {{ args }} || exit 1
 
 # wrap `uv lock`: update `uv.lock` if dependencies in `pyproject.toml` have changed
 lock *args: virtualenv (_uv "lock " + args)
@@ -144,7 +144,7 @@ lint *args=".": devenv
     $BIN/ruff check {{ args }}
 
 # run the various dev checks but does not change any files
-check: format lint
+check: (_uv "lock --check") format lint
     #!/usr/bin/env bash
     docker run --rm -i ghcr.io/hadolint/hadolint:v2.12.0-alpine < Dockerfile
 


### PR DESCRIPTION
- (Does not guarantee that this is now mess-free.)
- Now following https://hynek.me/articles/docker-uv/ a bit more
- Tidies up the stuff done in https://github.com/alarthast/testing-goat/pull/54, particularly https://github.com/alarthast/testing-goat/commit/3196e4ae56d57b6c1c6a3751c5fa040210acf1af

The article says that `--locked` is probably more appropriate than `--frozen` for use in CI.

I agree but don't want to copy-paste the lockfile timestamp extraction logic into the dockerfile,
so I'll use `--frozen`, but get `just check` to validate the lockfile so that for a properly protected default branch,
outdated lockfiles would cause error at the CI stage.

Proof that the recipe fails on CI for an invalid lockfile:
https://github.com/alarthast/testing-goat/actions/runs/14471509092/job/40586401788